### PR TITLE
Fix: Correct D3 link rendering call to diagonal function

### DIFF
--- a/main.js
+++ b/main.js
@@ -193,7 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         linkEnter.merge(link).transition()
             .duration(duration)
-            .attr("d", diagonal);
+            .attr("d", d => diagonal({ source: d.parent, target: d }));
 
         link.exit().transition()
             .duration(duration)


### PR DESCRIPTION
The previous implementation incorrectly called the `diagonal` path generator for links. It passed the target node `d` directly, instead of an object of the form `{ source: d.parent, target: d }` which the `diagonal` function expects.

This likely caused the "Cannot read properties of undefined (reading 'y')" error when the `diagonal` function tried to access properties on `d.source` (which is not a standard D3 hierarchy property and would be undefined).

This commit corrects the call to ensure `diagonal` receives the proper `source` and `target` node objects with their layout-assigned `x` and `y` coordinates.